### PR TITLE
Use pre-built image from docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/bitnami/helm-crd/
 COPY . .
 RUN make controller-static
 
-FROM alpine:latest
+FROM alpine:3.6
 RUN apk --no-cache add ca-certificates
 COPY --from=gobuild /go/src/github.com/bitnami/helm-crd/controller-static /controller
 CMD ["/controller"]

--- a/deploy/tiller-crd.jsonnet
+++ b/deploy/tiller-crd.jsonnet
@@ -19,8 +19,7 @@ local controller_overlay = {
           },
           {
             name: "controller",
-            image: "helm-crd-controller:latest",
-            imagePullPolicy: "Never",
+            image: "bitnami/helm-crd-controller:latest",
             securityContext: {
               readOnlyRootFilesystem: true,
             },

--- a/deploy/tiller-crd.yaml
+++ b/deploy/tiller-crd.yaml
@@ -62,8 +62,7 @@ spec:
         env:
         - name: TMPDIR
           value: /helm
-        image: helm-crd-controller:latest
-        imagePullPolicy: Never
+        image: bitnami/helm-crd-controller:latest
         name: controller
         securityContext:
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Switch to using autobuilt image from docker hub.  Also, pin alpine
base image to a specific version, to ease rebuildability.