### PR TITLE
Add a basic client as a kubectl plugin

### DIFF
--- a/plugin/helm/helm
+++ b/plugin/helm/helm
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -e
+test $KUBECTL_PLUGINS_GLOBAL_FLAG_V -gt 4 && set -x
+alias kubectl="$KUBECTL_PLUGINS_CALLER -n $KUBECTL_PLUGINS_CURRENT_NAMESPACE"
+
+values_yaml() {
+    if [ "$KUBECTL_PLUGINS_LOCAL_FLAG_VALUES" != "" ]; then
+        cat "$KUBECTL_PLUGINS_LOCAL_FLAG_VALUES"
+    fi
+
+    IFS=,; set -- $KUBECTL_PLUGINS_LOCAL_FLAG_SET; IFS=
+    for kv; do
+        echo "${kv%%=*}: \"${kv#*=}\""
+    done
+}
+
+json_escape() {
+    sed 's/([\"])/\\\1/g'
+}
+
+subcommand="$1"; shift
+case $subcommand in
+    init)
+        kubectl apply -n kube-system -f "$KUBECTL_PLUGINS_LOCAL_FLAG_URL"
+        ;;
+
+    list)
+        kubectl get helmreleases "$@"
+        ;;
+
+    install)
+        chart="$1"; shift
+        {
+            cat <<EOF
+apiVersion: helm.bitnami.com/v1
+kind: HelmRelease
+metadata:
+  name: $KUBECTL_PLUGINS_LOCAL_FLAG_NAME
+  generateName: ${chart}-
+spec:
+  repoUrl: $KUBECTL_PLUGINS_LOCAL_FLAG_REPO
+  chartName: $chart
+  version: $KUBECTL_PLUGINS_LOCAL_FLAG_VERSION
+  values: |
+EOF
+            values_yaml | sed 's/^    //'
+        } |
+            kubectl create -f-
+        ;;
+
+    upgrade)
+        name="$1"; shift
+
+        values=$(values_yaml)
+        patch=$(cat <<EOF)
+{"spec":
+${KUBECTL_PLUGINS_LOCAL_FLAG_REPO:+"repoUrl": $KUBECTL_PLUGINS_LOCAL_FLAG_REPO}
+${KUBECTL_PLUGINS_LOCAL_FLAG_VERSION:+"version": $KUBECTL_PLUGINS_LOCAL_FLAG_VERSION}
+${values:+"values": "$(echo $values | json_escape)"}
+}
+EOF
+        kubectl patch helmrelease $name -p "$patch"
+        ;;
+
+    delete)
+        kubectl delete helmrelease "$@"
+        ;;
+
+    *)
+        echo "Unknown subcommand: $subcommand" >&2
+        exit 1
+esac

--- a/plugin/helm/plugin.yaml
+++ b/plugin/helm/plugin.yaml
@@ -1,0 +1,69 @@
+name: helm
+shortDesc: Helm chart plugin
+tree:
+  - name: init
+    shortDesc: initialize Helm-CRD on server
+    longDesc: |
+      This command installs Tiller (the Helm server-side component) onto your
+      Kubernetes Cluster and sets up the Helm CRD controller.
+
+      Note this command installs tiller into kube-system, ignoring
+      the usual --namespace flag.
+    command: "./helm init"
+    flags:
+      - name: url
+        desc: URL of YAML to install
+        defValue: "https://raw.githubusercontent.com/bitnami/helm-crd/master/deploy/tiller-crd.yaml"
+
+  - name: list
+    shortDesc: list releases
+    command: "./helm list"
+
+  - name: install
+    shortDesc: install a chart archive
+    command: "./helm install"
+    example: |
+      kubectl plugin helm install -f myvalues.yaml --name mariadb mariadb
+      kubectl plugin helm install --set name=prod --name mariadb mariadb
+    flags:
+      - name: name
+        desc: release name. If unspecified, it will autogenerate one for you
+      - name: repo
+        desc: "chart repository url where to locate the requested chart"
+        defValue: "https://kubernetes-charts.storage.googleapis.com"
+      - name: version
+        desc: specify the exact chart version to install
+      - name: values
+        shorthand: f
+        desc: specify values in a YAML file
+      - name: set
+        desc: >-
+          set values on the command line (can specify separate
+          values with commas: key1=val1,key2=val2)
+
+  - name: upgrade
+    shortDesc: upgrade a release
+    command: "./helm upgrade"
+    example: |
+      kubectl plugin helm upgrade -f myvalues.yaml mariadb
+      kubectl plugin helm upgrade --version 1.2.3 mariadb
+    flags:
+      - name: repo
+        desc: "chart repository url where to locate the requested chart"
+        defValue: "https://kubernetes-charts.storage.googleapis.com"
+      - name: version
+        desc: specify the exact chart version to install
+      - name: values
+        shorthand: f
+        desc: specify values in a YAML file
+      - name: set
+        desc: >-
+          set values on the command line (can specify multiple or separate
+          values with commas: key1=val1,key2=val2)
+
+  - name: delete
+    shortDesc: >-
+      given a release name, delete the release from Kubernetes
+    command: "./helm delete"
+    example: |
+      kubectl plugin helm delete mariadb redis


### PR DESCRIPTION
This change adds a basic client that will interact with HelmRelease
CRD objects.  It implements basic init/list/install/update/delete
commands modeled after the real `helm` cli tool.

To install, copy `<repo>/plugin/helm/` dir to `~/.kube/plugins/helm/`
and then run `kubectl plugin helm ...`