### PR TITLE
Fix broken tiller command line

### DIFF
--- a/deploy/tiller-crd.jsonnet
+++ b/deploy/tiller-crd.jsonnet
@@ -17,6 +17,7 @@ local controller_overlay = {
             assert self.name == "tiller",
             // Nuke exposed tiller port
             ports: [], // Informational only
+            command: ["/tiller"],
             args+: ["--listen=localhost:44134"],  // Restrict to pod only
           },
           {

--- a/deploy/tiller-crd.yaml
+++ b/deploy/tiller-crd.yaml
@@ -34,6 +34,8 @@ spec:
       containers:
       - args:
         - --listen=localhost:44134
+        command:
+        - /tiller
         env:
         - name: TILLER_NAMESPACE
           value: kube-system


### PR DESCRIPTION
Breakfix for #7 
Added `args` without defining `command` :(